### PR TITLE
Adding Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: node_js
+
+node_js:
+  - '6'
+
+cache:
+  directories:
+    - node_modules

--- a/client/src/components/create-league/CreateLeagueForm.jsx
+++ b/client/src/components/create-league/CreateLeagueForm.jsx
@@ -70,9 +70,6 @@ class CreateLeagueForm extends Component {
 //redux-form method to access form field values
 const selector = formValueSelector('CreateLeagueForm');
 
-//Decorate component with redux-form
-CreateLeagueForm = reduxForm({ form: 'CreateLeagueForm', validate })(CreateLeagueForm);
-
 // Callback function passed to the connect function to access the form state
 function mapFormStateToProps(state){
 	return {SelectedSportType: selector(state, 'sportType')};
@@ -82,10 +79,14 @@ function mapDispatchToProps(dispatch){
 	return bindActionCreators({ createLeague }, dispatch);
 }
 
-//Decorate component with redux bindings
-CreateLeagueForm = connect(mapFormStateToProps, mapDispatchToProps)(CreateLeagueForm);
-
 //Decorate component one last time with react-router bindings in order to redirect user
 //after a successful form submission
-export default withRouter(CreateLeagueForm);
-
+export default withRouter(
+	//Decorate component with redux bindings
+	connect(mapFormStateToProps, mapDispatchToProps)(
+		//Decorate component with redux-form
+		reduxForm({ form: 'CreateLeagueForm', validate })(
+			CreateLeagueForm
+		)
+	)
+);

--- a/client/src/components/dashboard/leagueTabs/tab_navbar/linkTemplate.jsx
+++ b/client/src/components/dashboard/leagueTabs/tab_navbar/linkTemplate.jsx
@@ -23,7 +23,7 @@ const LinkTemplate = props => {
 				tooltip={description}
 				touch={true}
 				style={iconButton.style}
-				iconStyle={ linkIsActive ? iconButton.iconStyle : "" } 
+				iconStyle={ linkIsActive ? iconButton.iconStyle : '' } 
 				hoveredStyle={iconButton.hoveredStyle}
 			>
 				{icon}

--- a/client/src/components/dashboard/teams/forms/editTeamForm.jsx
+++ b/client/src/components/dashboard/teams/forms/editTeamForm.jsx
@@ -22,7 +22,7 @@ class EditTeamForm extends Component {
 	handleToggle() {
 		console.log('toggled');
 		this.setState({
-			active: !this.state.active ? "Active" : "Archived",
+			active: !this.state.active ? 'Active' : 'Archived',
 		});
 		console.log('toggled');
 	}

--- a/client/src/components/nav/ThemeMenu.jsx
+++ b/client/src/components/nav/ThemeMenu.jsx
@@ -20,10 +20,10 @@ function generateThemeIcons(themeList, themeNames, changeTheme) {
 				<i style={Object.assign(
 						{},
 						css.themeMenuItem,
-						{
-							backgroundColor: themeList[themeName].primary1Color,
-							border: '2px solid ' + themeList[themeName].accent1Color
-						})
+					{
+						backgroundColor: themeList[themeName].primary1Color,
+						border: '2px solid ' + themeList[themeName].accent1Color,
+					})
 					}
 					key={i}
 					onClick={changeTheme.bind(null, themeName)}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "lint": "eslint . --ext .js,.jsx",
     "lint:autoFix": "eslint . --fix --ext .js,.jsx",
     "pretest": "npm run lint",
+    "test": "echo \"No tests\"",
     "dev": "nodemon index.js --ignore client"
   },
   "author": "",

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "lint": "npm run lintServer:js && npm run lintClient:js",
-    "lintServer:js": "eslint server/**/*.js server/**/*.jsx webpack.*.js index.js --cache",
-    "lintClient:js": "eslint client/**/*.js client/**/*.jsx --cache",
-    "lint:autoFix": "eslint --fix server/**/*.js server/**/*.jsx client/**/*.js client/**/*.jsx",
+    "lint": "eslint . --ext .js,.jsx",
+    "lint:autoFix": "eslint . --fix --ext .js,.jsx",
+    "pretest": "npm run lint",
     "dev": "nodemon index.js --ignore client"
   },
   "author": "",


### PR DESCRIPTION
I've added Travis CI to the codebase and made part of the CI build run `eslint`. This gets the repository all set up for automatically checking tests on PRs in the future! I also tweaked the `package.json` to make the linting script more inclusive and readable. I didn't really see a need to keep different commands for linting the client verse the server, since we'll want all checks passing on future PRs regardless of which code was touched.

As part of getting the Travis build to pass, I fixed the two `no-class-assign` errors . There were a few different ways to go about it:

1. Wrapping all the decorators in the export statement
2. Using [actual decorators](https://github.com/wycats/javascript-decorators)
3. Having temporary variables instead of overwriting the class

I felt option 1 was best, given that decorators are still fairly new and subject to change, and the temporary variable hardly seems like a _great_ fix. But let me know if you think differently. I'm open to change!

If you pull in this PR, we'll need to enable Travis CI for the repository. I'm not sure who would need to do this (possibly @CodeNonprofit?), but it's not difficult at all!