### PR TITLE
Tab Defaults

### DIFF
--- a/client/src/components/dashboard/leagueTabs/leagueTabs.jsx
+++ b/client/src/components/dashboard/leagueTabs/leagueTabs.jsx
@@ -28,7 +28,7 @@ const LeagueTabs = ({history, leagueId}) => {
 						label={tab.name}
 						key={i}
 						style={css_dashboard.tabs.tab}
-						onActive={()=> history.push('/dashboard')}
+						onActive={()=> history.push(tab.links[0].url)}
 					>
 						{generateLinks(tab.links, leagueId)}
 						{routes[tab.name]}	

--- a/client/src/components/nav/Menu.jsx
+++ b/client/src/components/nav/Menu.jsx
@@ -6,6 +6,7 @@ import {List, ListItem} from 'material-ui/List';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import Help from 'material-ui/svg-icons/action/help';
 import LogOutIcon from 'material-ui/svg-icons/action/exit-to-app';
+import  * as Links  from '../routes';
 
 import Avatar from 'material-ui/Avatar';
 
@@ -25,7 +26,7 @@ const Menu = props => {
 							key={i}
 							primaryText={league.name}
 							onClick={() => selectLeague(league)}
-							containerElement={<Link to="/dashboard"/>}
+							containerElement={<Link to={Links.TEAM_LIST}/>}
 							leftIcon={<Avatar  
 								backgroundColor={css_menu.avatar.backgroundColor}
 								src={SportsIcons[league.sport_type]}/>}


### PR DESCRIPTION
This creates a few defaults around selecting tabs:

1. Selecting a league from the menu will default to the team list page
2. Selecting "Teams", "Players", "Seasons", or "Settings" defaults to opening the first sub option (e.g. clicking players opens up the player list)

I feel like this is a better user experience since it saves the user a click and gives them access to information immediately.