### PR TITLE
Adding tape and some sample unit tests for models

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "eslint . --ext .js,.jsx",
     "lint:autoFix": "eslint . --fix --ext .js,.jsx",
     "pretest": "npm run lint",
-    "test": "echo \"No tests\"",
+    "test": "tape **/__tests__/*.test.js",
     "dev": "nodemon index.js --ignore client"
   },
   "author": "",
@@ -61,6 +61,7 @@
     "file-loader": "^0.11.1",
     "html-webpack-plugin": "^2.26.0",
     "image-webpack-loader": "^3.3.0",
+    "tape": "^4.6.3",
     "url-loader": "^0.5.8",
     "webpack": "^2.2.0",
     "webpack-dev-middleware": "^1.9.0"

--- a/server/models/__tests__/player.test.js
+++ b/server/models/__tests__/player.test.js
@@ -1,0 +1,62 @@
+var test = require('tape');
+const mongoose = require('mongoose');
+const Player = require('../player');
+
+test('missing player fields present error message', (assert) => {
+	var player = new Player();
+	const error = player.validateSync();
+
+	assert.assert(error.errors.first_name, 'has first name missing message');
+	assert.assert(error.errors.last_name, 'has last name missing message');
+	assert.assert(error.errors.email, 'has email missing message');
+	assert.end();
+});
+
+test('player has all fields', (assert) => {
+	const playerData = {
+		first_name: 'Test',
+		last_name: 'Testerton',
+		phone_num: '123-456-7890',
+		emergency_contact: {
+			name: 'Test Emergency Name',
+			phone_num: '123-456-7890',
+			email: 'test@test.com',
+			relation: 'Test Relation',
+		},
+		address: {
+			street: '123 Test St.',
+			city: 'Test',
+			state: 'Testerton',
+			country: 'Test Country',
+		},
+	};
+
+	var player = new Player(playerData);
+
+	assert.equal(player.first_name, playerData.first_name, 'has first name');
+	assert.equal(player.last_name, playerData.last_name, 'has last name');
+	assert.equal(player.phone_num, playerData.phone_num, 'has phone number');
+	assert.equal(player.emergency_contact.name, playerData.emergency_contact.name, 'has emergency contact name');
+	assert.equal(player.emergency_contact.phone_num, playerData.emergency_contact.phone_num, 'has emergency contact phone number');
+	assert.equal(player.emergency_contact.email, playerData.emergency_contact.email, 'has emergency contact email');
+	assert.equal(player.emergency_contact.relation, playerData.emergency_contact.relation, 'has emergency contact relation');
+	assert.equal(player.address.street, playerData.address.street, 'has address street');
+	assert.equal(player.address.city, playerData.address.city, 'has address city');
+	assert.equal(player.address.state, playerData.address.state, 'has address state');
+	assert.equal(player.address.country, playerData.address.country, 'has address country');
+	assert.assert(player.leagues, 'has leagues');
+	assert.assert(player.teams, 'has teams');
+	assert.end();
+});
+
+test('player has computed fields', (assert) => {
+	const playerData = {
+		first_name: 'Test',
+		last_name: 'Testerton',
+	};
+
+	var player = new Player(playerData);
+
+	assert.equal(player.full_name, playerData.first_name + ' ' + playerData.last_name, 'has full name');
+	assert.end();
+});

--- a/server/models/__tests__/user.test.js
+++ b/server/models/__tests__/user.test.js
@@ -1,0 +1,29 @@
+var test = require('tape');
+const mongoose = require('mongoose');
+const User = require('../user');
+
+test('missing user fields present error message', (assert) => {
+	var user = new User();
+	const error = user.validateSync();
+
+	assert.assert(error.errors.name, 'has name missing message');
+	assert.assert(error.errors.email, 'has email missing message');
+	assert.end();
+});
+
+test('user has all fields', (assert) => {
+	const userData = {
+		name: 'Test Name',
+		email: 'test@test.com',
+		avatar: 'testAvatar',
+		google_id: 'testGoogleId',
+	};
+
+	var user = new User(userData);
+
+	assert.equal(user.name, userData.name, 'has name');
+	assert.equal(user.email, userData.email, 'has email');
+	assert.equal(user.avatar, userData.avatar, 'has avatar');
+	assert.equal(user.google_id, userData.google_id, 'has Google ID');
+	assert.end();
+});


### PR DESCRIPTION
I've added Tape. It's the unit testing framework used by the main FreeCodeCamp site, so I figured that would be a good choice. It's pretty straightforward to use, and I've enjoyed it so far!

Included are two samples of testing the models to make sure the have the right fields. If you think this would be useful, I can continue on testing all the other models as well, and we can expand the unit tests to other parts of the codebase after.

Here are the design decisions I've made that I wanted to run by you both to get your feedback:

- **I chose the pattern of adding a `__tests__` folder to each directory**, so that tests live near the code they are testing. It's a common pattern I've seen, but I'm open to switching it to something else (like a dedicated `tests` folder) if desired.
- **I've also added the `npm run test` command that will run all the test files** (which need to be named `_something_.test.js` in the `__tests__` folder).
- **Tests won't run if the linter doesn't pass**, so we'll have to make sure we fix the outstanding linter issues and keep those clean. Once we have TravisCI set up, it will be really easy to catch those issues on PRs.

Let me know if you'd like to take a different approach with any of the above!