### PR TITLE
[#8] Switching to native promises and adding mongoose.disconnect.

### DIFF
--- a/init/initRoles.js
+++ b/init/initRoles.js
@@ -29,7 +29,7 @@ const mongoose = require('mongoose');
 const Role = mongoose.model('role');
 const MONGO_URI = process.env.MONGO_URI;
 
-
+mongoose.Promise = global.Promise;
 mongoose.connect(MONGO_URI);
 mongoose.connection
     .once('open', () => console.log('Connected to MongoDB'))
@@ -117,5 +117,11 @@ const coachPromise = coachRole.save()
 	.then(() => console.log('Coach role added'));
 
 Promise.all([adminPromise, managerPromise, coachPromise])
-	.then(() => console.log('Roles added'))
-	.catch(err => console.log(err));
+	.then(() => {
+		console.log('Roles added');
+		mongoose.disconnect();
+	})
+	.catch(err => {
+		console.log(err);
+		mongoose.disconnect();
+	});

--- a/seed.mongo.js
+++ b/seed.mongo.js
@@ -1,1 +1,0 @@
-// mongo ds139899.mlab.com:39899/league-for-good -u ahstein3521 -p


### PR DESCRIPTION
Hey @makkoli, try running this and see if you still see that error. I couldn't reproduce what you were seeing when I added `mongoose.disconnect();` though.

This switches to native JS promises, which gets rid of the following depreciation warning:
`DeprecationWarning: Mongoose: mpromise (mongoose's default promise library) is deprecated, plug in your own promise library instead: http://mongoosejs.com/docs/promises.html`

It's possible moving to native promises might fix the issue on your end. Give it a go and let me know if it's fixed!