### PR TITLE
Update refactor league reducer

### DIFF
--- a/client/src/actions/auth.js
+++ b/client/src/actions/auth.js
@@ -20,7 +20,11 @@ export function initAuthState() {
 
 				// send user's leagues to reducer
 				if (leagueInfo) {
-					dispatch({ type: FETCH_LEAGUES, leagueInfo });
+
+					let leagueObj = leagueInfo.reduce((obj, league) =>
+						({...obj, [league._id]: league}), {});
+
+					dispatch({ type: FETCH_LEAGUES, leagueInfo: leagueObj });
 					dispatch({ type: FETCH_ROLES, roles });
 				}
 			})

--- a/client/src/components/dashboard/dashboard.jsx
+++ b/client/src/components/dashboard/dashboard.jsx
@@ -42,9 +42,10 @@ Dashboard.propTypes = {
 };
 
 function mapStateToProps(state) {
+	const { selected, ...leagues } = state.league;
 
 	return {
-		league: state.league.selected,
+		league: leagues[selected],
 		isLoading: state.isLoading
 	};
 }

--- a/client/src/components/nav/Menu.jsx
+++ b/client/src/components/nav/Menu.jsx
@@ -15,7 +15,6 @@ import Avatar from 'material-ui/Avatar';
 import {SportsIcons} from '../sports';
 import { cssMenu } from '../style';
 
-
 const Menu = props => {
 	const { open, leagues, selectLeague, openModal } = props;
 

--- a/client/src/components/nav/index.jsx
+++ b/client/src/components/nav/index.jsx
@@ -71,8 +71,13 @@ NavBar.propTypes = {
 
 function mapStateToProps({menu, league}) {
 	const { open } = menu;
-
-	return { open, leagues: league.list };
+	let { selected, ...leagues } = league;
+	const keys = Object.keys(leagues);
+	leagues = keys.map(key => {
+		const isSelected = selected === key;
+		return { ...leagues[key], isSelected };
+	})
+	return { open, leagues };
 }
 
 function mapDispatchToProps(dispatch) {

--- a/client/src/components/nav/index.jsx
+++ b/client/src/components/nav/index.jsx
@@ -76,7 +76,7 @@ function mapStateToProps({menu, league}) {
 	leagues = keys.map(key => {
 		const isSelected = selected === key;
 		return { ...leagues[key], isSelected };
-	})
+	});
 	return { open, leagues };
 }
 

--- a/client/src/reducers/league.js
+++ b/client/src/reducers/league.js
@@ -1,3 +1,4 @@
+import { omit } from 'lodash';
 import {
 	FETCH_LEAGUES,
 	CREATE_LEAGUE,
@@ -7,46 +8,44 @@ import {
 
 /*
 	League State
+	-------------
+	This piece of state is one big object which is a series of key-value pairs
+	with the format 'leagueId': leagueDataObject
 
-	list -     (Array) - List of all leagues objects associated w user
-	selected - (Object)- The league being displayed
+	In addition there is a property 'selected' whose value is a
+	string of the leagueId if there is a currently selected league or null
 
+	example state w/ NBA selected:
+		{
+			L100: { name: 'NBA', sportType: 'BasketBall', _id: 'L100' },
+			L101: { name: 'MLB', sportType: 'Baseball', _id: 'L101' },
+			selected: 'L100'
+		}
 */
 
-const removeReg = ({ selected: { pendingPlayers, ...rest }}, _id) => {
-	const updatedArr = pendingPlayers.filter(p => p._id !== _id);
-	return { ...rest, pendingPlayers: updatedArr };
-};
-
-
-const defaultState = { list: [], selected: {} };
+const defaultState = { selected: null };
 
 export default function(state = defaultState, action) {
 
 	switch (action.type) {
 
 	case REMOVE_LEAGUE:
-		return {
-			selected: {},
-			list: state.list
-				.filter(league => league._id !== action.leagueId)
-		};
+
+		return { ...omit(state, action.leagueId), selected: null };
 
 	case CREATE_LEAGUE:
-		return {...state, list: [...state.list, action.newLeague]};
+		return {...state, [action.newLeague._id]: action.newLeague };
 
 	case FETCH_LEAGUES:
-		return {...state, list: action.leagueInfo };
+		console.log(action.leagueInfo);
+		return { ...state, ...action.leagueInfo };
 
 	case SELECT_LEAGUE:
-		return {
-			...state,
-			selected: state.list.find(
-				league => league._id === action.leagueId)
-		};
+		return { ...state, selected: action.leagueId };
 
-	case 'REMOVE_REGISTRATION':
-		return { ...state, selected: removeReg(state, action.payload) };
+	// case 'REMOVE_REGISTRATION':
+
+	// 	return { ...state, selected: removeReg(state, action.payload) };
 
 	default:
 		return state;

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -26,9 +26,9 @@ function logOutUser(req, res) {
 //		Roles to determine proper access to those league
 function fetchInitialData(req, res, next) {
 	const { user } = req;
-
+	;
 	if (!user) {return next();}
-
+	
 	const query = { $or: [ { owner: user._id }, { 'staff.email': user.email } ] };
 
 	const leaguePromise = Leagues.find(query)
@@ -39,6 +39,7 @@ function fetchInitialData(req, res, next) {
 	return Promise.all([leaguePromise.exec(), rolePromise.exec()])
 		.then(initData => {
 			const [leagueInfo, roles] = initData;
+
 			res.send({user, leagueInfo, roles, loggedIn: true });
 		})
 		.catch((err) => res.send(err));

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -26,9 +26,9 @@ function logOutUser(req, res) {
 //		Roles to determine proper access to those league
 function fetchInitialData(req, res, next) {
 	const { user } = req;
-	;
+
 	if (!user) {return next();}
-	
+
 	const query = { $or: [ { owner: user._id }, { 'staff.email': user.email } ] };
 
 	const leaguePromise = Leagues.find(query)

--- a/server/models/player.js
+++ b/server/models/player.js
@@ -69,10 +69,6 @@ PlayerSchema.virtual('fullName').get(function() {
 	return `${this.firstName} ${this.lastName}`;
 });
 
-// TODO -- virtual should return team config relative to league AND seasonId
-PlayerSchema.virtual('team').get(function() {
-	return this.teams[0];
-});
 
 PlayerSchema.plugin(removeRefs, {
 	modelName: 'league', field: 'pendingPlayers'


### PR DESCRIPTION
I changed the league reducer in the following ways:

- There is no longer a 'list' property containing an array for each league object. Instead, each league's _id value is now a key on an object which corresponds to that specific league. 

- The 'selected' property value is no longer an entire league object, but rather a string of the league _id to be used to reference the league. This will help to prevent 2 different versions of the same league from existing in state. I also used this to set up an _isSelected_ flag on each league object, so we can display some sort of alternate styling on the menu.   