### PR TITLE
Fixed issue with menu 'drawer' not closing when hamburger clicked

### DIFF
--- a/client/src/components/nav/Bar.jsx
+++ b/client/src/components/nav/Bar.jsx
@@ -28,7 +28,8 @@ const Bar = props => {
 		<AppBar
 			iconElementRight={ <ThemeIcon {...iconProps} />}
 			iconStyleLeft={css.text}
-			onLeftIconButtonTouchTap={() => toggleMenu()}
+			onLeftIconButtonClick={toggleMenu}
+			onLeftIconButtonTouchTap={toggleMenu}
 			style={css.main}
 			title='League For Good'
 			titleStyle={css.text}


### PR DESCRIPTION
Fix for issue #98 - added `onLeftIconButtonClick` to the `AppBar` and refactored `onLeftIconButtonTouchTap`.