### PR TITLE
Add "archive leagues" feature (#97)

### DIFF
--- a/client/src/actions/league.js
+++ b/client/src/actions/league.js
@@ -94,3 +94,32 @@ export function selectLeague(leagueId) {
 	};
 
 }
+
+export function switchArchiveLeague(formVals, dispatch, props) {
+	const { archived } = formVals;
+	const { leagueId } = props;
+	const leagueName = props.leagueInfo.name;
+	const { sportType } = props.leagueInfo;
+	const url = `${ROOT_URL}/league/update/${leagueId}`;
+	const body = {
+		archived
+	};
+	axios.put(url, body)
+		.then(() => {
+			return dispatch({
+				type: EDIT_LEAGUE,
+				archived,
+				payload: {
+					[leagueId]: {
+						_id: leagueId,
+						name: leagueName,
+						sportType: sportType,
+						archived: archived
+					}
+				}
+			});
+		})
+		.catch(error => {
+			throw new Error(error);
+		});
+}

--- a/client/src/actions/league.js
+++ b/client/src/actions/league.js
@@ -43,6 +43,7 @@ export function deleteLeague(_, dispatch, props) {
 export function editLeague(formVals, dispatch, props) {
 	const { leagueName } = formVals;
 	const { leagueId } = props;
+	const archived = props.leagueInfo.archived === true;
 	const { sportType } = props.leagueInfo;
 	const url = `${ROOT_URL}/league/update/${leagueId}`;
 	const body = {
@@ -57,7 +58,8 @@ export function editLeague(formVals, dispatch, props) {
 					[leagueId]: {
 						_id: leagueId,
 						name: leagueName,
-						sportType: sportType
+						sportType: sportType,
+						archived: archived
 					}
 				}
 			});

--- a/client/src/components/dashboard/leagueTabs/leagueTabData.js
+++ b/client/src/components/dashboard/leagueTabs/leagueTabData.js
@@ -7,6 +7,7 @@ import ModeEditIcon from 'material-ui/svg-icons/editor/mode-edit';
 import EmailIcon from 'material-ui/svg-icons/communication/email';
 import AssignmentIcon from 'material-ui/svg-icons/action/assignment';
 import ListIcon from 'material-ui/svg-icons/action/view-list';
+import ArchiveIcon from 'material-ui/svg-icons/content/archive';
 // import EventIcon from 'material-ui/svg-icons/action/event';
 
 import * as LINK from '../../routes';
@@ -93,6 +94,12 @@ const settingsLinks = [
 		label: 'EditLeague',
 		icon: <ModeEditIcon />,
 		url: LINK.SETTINGS_EDIT_LEAGUE_NAME
+	},
+	{
+		description: 'Archive League',
+		label: 'ArchiveLeague',
+		icon: <ArchiveIcon />,
+		url: LINK.SETTINGS_EDIT_ARCHIVE_LEAGUE
 	}
 //	{
 //		description: 'Delete your league.',

--- a/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
+++ b/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
@@ -16,7 +16,7 @@ const LeagueArchiveForm = props => {
                     <Field
                         checked={props.initialValues.archived}
                         component={Checkbox}
-                        label='Check if team should be archived'
+                        label='Check if league should be archived'
                         labelPosition='left'
                         labelStyle={cssDashboard.settings.forms.archive.label}
                         name='archived'

--- a/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
+++ b/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { Field, reduxForm } from 'redux-form';
+import { Checkbox } from 'redux-form-material-ui';
+import PropTypes from 'prop-types';
+
+import { cssContent, cssDashboard } from '../../../styles';
+import { editLeague, openSnackbar } from '../../../../actions/index';
+import { connect } from 'react-redux';
+
+const LeagueArchiveForm = props => {
+    // this appears to be a ref, function actually loads in the
+    // connect->reduxForm?
+    const { handleSubmit } = props;
+    // console.log(props);
+    // const checked = props.leagueInfo && props.leagueInfo.archived;
+    // console.log(checked);
+    console.log(props.leagueInfo && props.leagueInfo.archived);
+    return (
+        <div style={cssContent.body}>
+            <h1 style={cssDashboard.title}>Enter New League Name</h1>
+            <form
+                onSubmit={handleSubmit}
+                style={cssDashboard.form}
+                >
+                <div style={cssDashboard.teams.forms.edit.checkboxDiv}>
+                    <Field
+                        checked={props.leagueInfo && props.leagueInfo.archived}
+                        component={Checkbox}
+                        label='Check if team is active'
+                        labelPosition='left'
+                        labelStyle={cssDashboard.teams.forms.edit.checkbox}
+                        name='archived'
+                    />
+                </div>
+            </form>
+        </div>
+    );
+};
+
+LeagueArchiveForm.propTypes = {
+    handleSubmit: PropTypes.func
+};
+
+function mapStateToProps(state) {
+    console.log('mapping state to props');
+    const id = state.league.selected;
+    return {
+        leagueId: state.league.selected,
+        leagueInfo: state.league[id],
+        snackbar: state.snackbar
+    };
+}
+
+export default connect(mapStateToProps)(reduxForm({
+    form: 'LeagueArchiveForm',
+    onSubmit: editLeague,
+    onSubmitSuccess: openSnackbar
+})(LeagueArchiveForm));
+
+// export default reduxForm({
+//     form: 'LeagueArchiveForm',
+//     onSubmit: editLeague,
+//     onSubmitSuccess: openSnackbar
+// })(LeagueArchiveForm);

--- a/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
+++ b/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
@@ -11,16 +11,14 @@ const LeagueArchiveForm = props => {
 
     return (
         <div style={cssContent.body}>
-            <form
-                style={cssDashboard.form}
-                >
-                <div style={cssDashboard.teams.forms.edit.checkboxWideDiv}>
+            <form>
+                <div style={cssDashboard.settings.forms.archive.checkboxDiv}>
                     <Field
                         checked={props.initialValues.archived}
                         component={Checkbox}
                         label='Check if team should be archived'
                         labelPosition='left'
-                        // labelStyle={cssDashboard.teams.forms.edit.checkboxWide}
+                        labelStyle={cssDashboard.settings.forms.archive.label}
                         name='archived'
                     />
                 </div>

--- a/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
+++ b/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
@@ -20,9 +20,8 @@ const LeagueArchiveForm = props => {
                         component={Checkbox}
                         label='Check if team should be archived'
                         labelPosition='left'
-                        labelStyle={cssDashboard.teams.forms.edit.checkboxWide}
+                        // labelStyle={cssDashboard.teams.forms.edit.checkboxWide}
                         name='archived'
-
                     />
                 </div>
             </form>

--- a/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
+++ b/client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx
@@ -4,32 +4,25 @@ import { Checkbox } from 'redux-form-material-ui';
 import PropTypes from 'prop-types';
 
 import { cssContent, cssDashboard } from '../../../styles';
-import { editLeague, openSnackbar } from '../../../../actions/index';
+import { switchArchiveLeague } from '../../../../actions/index';
 import { connect } from 'react-redux';
 
 const LeagueArchiveForm = props => {
-    // this appears to be a ref, function actually loads in the
-    // connect->reduxForm?
-    const { handleSubmit } = props;
-    // console.log(props);
-    // const checked = props.leagueInfo && props.leagueInfo.archived;
-    // console.log(checked);
-    console.log(props.leagueInfo && props.leagueInfo.archived);
+
     return (
         <div style={cssContent.body}>
-            <h1 style={cssDashboard.title}>Enter New League Name</h1>
             <form
-                onSubmit={handleSubmit}
                 style={cssDashboard.form}
                 >
-                <div style={cssDashboard.teams.forms.edit.checkboxDiv}>
+                <div style={cssDashboard.teams.forms.edit.checkboxWideDiv}>
                     <Field
-                        checked={props.leagueInfo && props.leagueInfo.archived}
+                        checked={props.initialValues.archived}
                         component={Checkbox}
-                        label='Check if team is active'
+                        label='Check if team should be archived'
                         labelPosition='left'
-                        labelStyle={cssDashboard.teams.forms.edit.checkbox}
+                        labelStyle={cssDashboard.teams.forms.edit.checkboxWide}
                         name='archived'
+
                     />
                 </div>
             </form>
@@ -38,27 +31,22 @@ const LeagueArchiveForm = props => {
 };
 
 LeagueArchiveForm.propTypes = {
-    handleSubmit: PropTypes.func
+    handleSubmit: PropTypes.func,
+    initialValues: PropTypes.object
 };
 
 function mapStateToProps(state) {
-    console.log('mapping state to props');
     const id = state.league.selected;
+    let archived = state.league[id]['archived'];
+    let initialValues = { archived };
     return {
+        initialValues,
         leagueId: state.league.selected,
-        leagueInfo: state.league[id],
-        snackbar: state.snackbar
+        leagueInfo: state.league[id]
     };
 }
 
 export default connect(mapStateToProps)(reduxForm({
     form: 'LeagueArchiveForm',
-    onSubmit: editLeague,
-    onSubmitSuccess: openSnackbar
+    onChange: switchArchiveLeague
 })(LeagueArchiveForm));
-
-// export default reduxForm({
-//     form: 'LeagueArchiveForm',
-//     onSubmit: editLeague,
-//     onSubmitSuccess: openSnackbar
-// })(LeagueArchiveForm);

--- a/client/src/components/dashboard/settings/forms/editLeageNameForm.jsx
+++ b/client/src/components/dashboard/settings/forms/editLeageNameForm.jsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { Field, reduxForm } from 'redux-form';
 import { TextField } from 'redux-form-material-ui';
 
+import PropTypes from 'prop-types';
+
 import { cssContent, cssDashboard } from '../../../styles';
 import RaisedButton from 'material-ui/RaisedButton';
 import { editLeague, openSnackbar } from '../../../../actions/index';
 import { connect } from 'react-redux';
 
 const EditLeageNameForm = props => {
+    // this appears to be a ref, function actually loads in the
+    // connect->reduxForm?
     const { handleSubmit } = props;
     return (
         <div style={cssContent.body}>
@@ -33,6 +37,10 @@ const EditLeageNameForm = props => {
             </form>
         </div>
     );
+};
+
+EditLeageNameForm.propTypes = {
+    handleSubmit: PropTypes.func
 };
 
 function mapStateToProps(state) {

--- a/client/src/components/dashboard/settings/forms/editLeageNameForm.jsx
+++ b/client/src/components/dashboard/settings/forms/editLeageNameForm.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import { Field, reduxForm } from 'redux-form';
 import { TextField } from 'redux-form-material-ui';
 
-import PropTypes from 'prop-types';
-
 import { cssContent, cssDashboard } from '../../../styles';
 import RaisedButton from 'material-ui/RaisedButton';
 import { editLeague, openSnackbar } from '../../../../actions/index';

--- a/client/src/components/dashboard/settings/routes.jsx
+++ b/client/src/components/dashboard/settings/routes.jsx
@@ -7,6 +7,7 @@ import * as Links from '../../routes';
 import AddStaffForm from './forms/addStaffForm.jsx';
 import StaffList from './staff_list/staffList.jsx';
 import EditLeagueNameForm from './forms/editLeageNameForm.jsx';
+import LeagueArchiveForm from './forms/LeagueArchiveForm.jsx';
 // SETTINGS_ADD_STAFF_FORM
 
 const SettingsRoutes = () => (
@@ -24,6 +25,11 @@ const SettingsRoutes = () => (
 			component={EditLeagueNameForm}
 			exact={true}
 			path={Links.SETTINGS_EDIT_LEAGUE_NAME}
+		/>
+		<Route
+			component={LeagueArchiveForm}
+			exact={true}
+			path={Links.SETTINGS_EDIT_ARCHIVE_LEAGUE}
 		/>
 	</div>
 );

--- a/client/src/components/nav/Menu.jsx
+++ b/client/src/components/nav/Menu.jsx
@@ -7,6 +7,7 @@ import Divider from 'material-ui/Divider';
 import {List, ListItem} from 'material-ui/List';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import Help from 'material-ui/svg-icons/action/help';
+import ArchiveIcon from 'material-ui/svg-icons/content/archive';
 import LogOutIcon from 'material-ui/svg-icons/action/exit-to-app';
 
 import MenuLeagueItem from './MenuLeagueItem.jsx';
@@ -16,7 +17,7 @@ import { cssMenu } from '../styles';
 const Menu = (props) => {
 	const { open, leagues, selectLeague, openModal } = props;
 	const activeLeagues = leagues.filter(league => league.archived === false);
-	const archivedLeagues = leagues.filter(league => league.archived !== false);
+	const archivedLeagues = leagues.filter(league => league.archived === true);
 	return (
 		<Drawer open={open} width={'15%'}>
 			<List style={cssMenu.drawer.list}>
@@ -36,6 +37,7 @@ const Menu = (props) => {
 				{archivedLeagues.length > 0 ? (
 					<div>
 						<ListItem
+							leftIcon={<ArchiveIcon style={cssMenu.icons} />}
 							nestedItems={[
 								archivedLeagues.map((league, i) => (
 									<MenuLeagueItem
@@ -46,23 +48,25 @@ const Menu = (props) => {
 								)
 								)
 							]}
-							primaryText='ARCHIVE'
+							primaryText='Archive'
+							primaryTogglesNestedList={true}
+							style={cssMenu.archive}
 						/>
 						< Divider />
 					</div>) : <noScript />
 				}
 				<ListItem
 					containerElement={<Link to='/create' />}
-					leftIcon={<AddCircle />}
+					leftIcon={<AddCircle style={cssMenu.icons} />}
 					primaryText='Create League'
 				/>
 				<ListItem
 					containerElement={<Link to='/help' />}
-					leftIcon={<Help />}
+					leftIcon={<Help style={cssMenu.icons} />}
 					primaryText='Help'
 				/>
 				<ListItem
-					leftIcon={<LogOutIcon/>}
+					leftIcon={<LogOutIcon style={cssMenu.icons} />}
 					onTouchTap={()=> openModal('logout')}
 					primaryText='Log out'
 				/>

--- a/client/src/components/nav/Menu.jsx
+++ b/client/src/components/nav/Menu.jsx
@@ -8,65 +8,48 @@ import {List, ListItem} from 'material-ui/List';
 import AddCircle from 'material-ui/svg-icons/content/add-circle';
 import Help from 'material-ui/svg-icons/action/help';
 import LogOutIcon from 'material-ui/svg-icons/action/exit-to-app';
-import * as Links from '../routes';
 
-import Avatar from 'material-ui/Avatar';
+import MenuLeagueItem from './MenuLeagueItem.jsx';
 
-import {SportsIcons} from '../sports';
 import { cssMenu } from '../styles';
 
-const Menu = props => {
+const Menu = (props) => {
 	const { open, leagues, selectLeague, openModal } = props;
-
+	const activeLeagues = leagues.filter(league => league.archived === false);
+	const archivedLeagues = leagues.filter(league => league.archived !== false);
 	return (
 		<Drawer open={open} width={'15%'}>
 			<List style={cssMenu.drawer.list}>
-				{
-					leagues.filter(league => league.archived === false)
-						.map((league, i) => {
-							console.log(league);
-							return (
-							<ListItem
-								containerElement={<Link to={Links.TEAM_LIST}/>}
+				{activeLeagues.length > 0 ? (
+					<div>
+						{activeLeagues.map((league, i) => (
+							<MenuLeagueItem
 								key={i}
-								leftIcon={
-									<Avatar
-										backgroundColor={cssMenu.avatar.backgroundColor}
-										src={SportsIcons[league.sportType]}
-									/>
-								}
-								onClick={() => selectLeague(league)}
-								primaryText={league.name}
+								league={league}
+								selectLeague={selectLeague}
 							/>
-							);
-						}
-					)
+							)
+						)}
+						< Divider />
+					</div>) : <noScript />
 				}
-				{ leagues.filter(league => league.archived === false).length > 0 ?
-					<Divider /> :
-					<noScript />
-				}
-				{
-					leagues.filter(league => league.archived === true)
-						.map((league, i) => (
-							<ListItem
-								containerElement={<Link to={Links.TEAM_LIST} />}
-								key={i}
-								leftIcon={
-									<Avatar
-										backgroundColor={cssMenu.avatar.backgroundColor}
-										src={SportsIcons[league.sportType]}
+				{archivedLeagues.length > 0 ? (
+					<div>
+						<ListItem
+							nestedItems={[
+								archivedLeagues.map((league, i) => (
+									<MenuLeagueItem
+										key={i}
+										league={league}
+										selectLeague={selectLeague}
 									/>
-								}
-								onClick={() => selectLeague(league)}
-								primaryText={league.name}
-							/>
-						)
-					)
-				}
-				{leagues.filter(league => league.archived === true).length > 0 ?
-					<Divider /> :
-					<noScript />
+								)
+								)
+							]}
+							primaryText='ARCHIVE'
+						/>
+						< Divider />
+					</div>) : <noScript />
 				}
 				<ListItem
 					containerElement={<Link to='/create' />}

--- a/client/src/components/nav/Menu.jsx
+++ b/client/src/components/nav/Menu.jsx
@@ -22,23 +22,52 @@ const Menu = props => {
 		<Drawer open={open} width={'15%'}>
 			<List style={cssMenu.drawer.list}>
 				{
-					leagues.map((league, i) => (
-						<ListItem
-							containerElement={<Link to={Links.TEAM_LIST}/>}
-							key={i}
-							leftIcon={
-								<Avatar
-									backgroundColor={cssMenu.avatar.backgroundColor}
-									src={SportsIcons[league.sportType]}
-								/>
-							}
-							onClick={() => selectLeague(league)}
-							primaryText={league.name}
-						/>
+					leagues.filter(league => league.archived === false)
+						.map((league, i) => {
+							console.log(league);
+							return (
+							<ListItem
+								containerElement={<Link to={Links.TEAM_LIST}/>}
+								key={i}
+								leftIcon={
+									<Avatar
+										backgroundColor={cssMenu.avatar.backgroundColor}
+										src={SportsIcons[league.sportType]}
+									/>
+								}
+								onClick={() => selectLeague(league)}
+								primaryText={league.name}
+							/>
+							);
+						}
+					)
+				}
+				{ leagues.filter(league => league.archived === false).length > 0 ?
+					<Divider /> :
+					<noScript />
+				}
+				{
+					leagues.filter(league => league.archived === true)
+						.map((league, i) => (
+							<ListItem
+								containerElement={<Link to={Links.TEAM_LIST} />}
+								key={i}
+								leftIcon={
+									<Avatar
+										backgroundColor={cssMenu.avatar.backgroundColor}
+										src={SportsIcons[league.sportType]}
+									/>
+								}
+								onClick={() => selectLeague(league)}
+								primaryText={league.name}
+							/>
 						)
 					)
 				}
-				{ leagues.length > 0 ? <Divider /> : <noScript /> }
+				{leagues.filter(league => league.archived === true).length > 0 ?
+					<Divider /> :
+					<noScript />
+				}
 				<ListItem
 					containerElement={<Link to='/create' />}
 					leftIcon={<AddCircle />}

--- a/client/src/components/nav/MenuLeagueItem.jsx
+++ b/client/src/components/nav/MenuLeagueItem.jsx
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { ListItem } from 'material-ui/List';
+import * as Links from '../routes';
+
+import Avatar from 'material-ui/Avatar';
+
+import { SportsIcons } from '../sports';
+import { cssMenu } from '../styles';
+
+const MenuLeagueItem = props => {
+    const { league, selectLeague } = props;
+
+    return (
+        <ListItem
+            containerElement={<Link to={Links.TEAM_LIST} />}
+            leftIcon={
+                <Avatar
+                    backgroundColor={cssMenu.avatar.backgroundColor}
+                    src={SportsIcons[league.sportType]}
+                />
+            }
+            onClick={() => selectLeague(league)}
+            primaryText={league.name}
+        />
+    );
+};
+
+MenuLeagueItem.propTypes = {
+    league: PropTypes.object,
+    selectLeague: PropTypes.func
+};
+
+export default MenuLeagueItem;

--- a/client/src/components/routes.js
+++ b/client/src/components/routes.js
@@ -22,6 +22,7 @@ export const SETTINGS_DELETE_LEAGUE = '/dashboard/settings/delete';
 export const SETTINGS_ADD_STAFF_FORM = '/dashboard/settings/create';
 export const SETTINGS_STAFF_LIST = '/dashboard/settings/staff';
 export const SETTINGS_EDIT_LEAGUE_NAME = '/dashboard/settings/leagueName';
+export const SETTINGS_EDIT_ARCHIVE_LEAGUE = '/dashboard/settings/archive';
 
 // Season routes
 export const SEASON_LIST = '/dashboard/seasons/list';

--- a/client/src/components/styles/cssDashboard.js
+++ b/client/src/components/styles/cssDashboard.js
@@ -128,14 +128,8 @@ export const cssDashboard = {
 				checkbox: {
 					width: '125px'
 				},
-				checkboxWide: {
-					width: '250px'
-				},
 				checkboxDiv: {
 					float: 'right'
-				},
-				checkboxWideDiv: {
-					float: 'left'
 				}
 			}
 		}
@@ -178,6 +172,14 @@ export const cssDashboard = {
 					padding: '0px',
 					textAlign: 'left',
 					float: 'right'
+				}
+			},
+			archive: {
+				label: {
+					width: '250px'
+				},
+				checkboxDiv: {
+					marginLeft: '20px'
 				}
 			}
 		}

--- a/client/src/components/styles/cssDashboard.js
+++ b/client/src/components/styles/cssDashboard.js
@@ -128,8 +128,14 @@ export const cssDashboard = {
 				checkbox: {
 					width: '125px'
 				},
+				checkboxWide: {
+					width: '250px'
+				},
 				checkboxDiv: {
 					float: 'right'
+				},
+				checkboxWideDiv: {
+					float: 'left'
 				}
 			}
 		}

--- a/client/src/components/styles/cssMenu.js
+++ b/client/src/components/styles/cssMenu.js
@@ -7,5 +7,11 @@ export const cssMenu = {
 	},
 	avatar: {
 		backgroundColor: 'none'
+	},
+	icons: {
+		fill: '#555'
+	},
+	archive: {
+		color: '#555'
 	}
 };

--- a/server/api/auth.js
+++ b/server/api/auth.js
@@ -33,7 +33,7 @@ function fetchInitialData(req, res, next) {
 	const query = { 'staff.email': user.email };
 
 	return Leagues.find(query)
-		.select('name _id sportType')
+		.select('name _id sportType archived')
 		.exec()
 		.then(leagueInfo => {
 			res.send({

--- a/server/api/league.js
+++ b/server/api/league.js
@@ -18,7 +18,8 @@ const createLeague = (req, res) => {
 			email: req.user.email,
 			role: roles.getOwnerRole(),
 			teams: []
-		}]
+		}],
+		archived: false
 	});
 
 	newLeague.save()
@@ -39,22 +40,28 @@ const fetchLeagueDetails = (req, res) => {
 	const fetchSeasons = Seasons.find({ leagueId })
 		.sort({ endDate: 1 });
 	const fetchTeams = Teams.find({ leagueId });
-	const fetchStaff = League.findOne({ _id: leagueId })
-				.select({ _id: 0, staff: 1});
+	const fetchLeague = League.findOne({ _id: leagueId })
+		.select({ _id: 0, staff: 1, archived: 1});
 
 	Promise.all([
 		fetchSeasons.exec(),
 		fetchTeams.exec(),
 		fetchPlayers.exec(),
-		fetchStaff.exec()
+		fetchLeague.exec()
 	])
-	.then(([seasons, teams, players, league]) =>
-		res.send({ teams, seasons, players, staff: league.staff })
-	);
+	.then(([seasons, teams, players, league]) => {
+		res.send({
+			teams,
+			seasons,
+			players,
+			staff: league.staff,
+			archived: league.archived
+		});
+	});
 
 };
 
-
+// remove this because we're not allowing complete deletion?
 const deleteLeague = (req, res) => {
 	const { leagueId } = req.params;
 

--- a/server/models/league.js
+++ b/server/models/league.js
@@ -31,6 +31,11 @@ const LeagueSchema = new Schema(
 			trim: true
 		},
 		settings: LeagueSettings,
+		archived: {
+			type: Boolean,
+			required: true,
+			default: false
+		},
 		staff: [{
 			role: String,
 			email: String,


### PR DESCRIPTION
Ability to archive leagues (since they can't be deleted), adding a new expandable 'Archive' entry in the `Menu` (material-ui Drawer element).

In `client/src/actions/league.js`
* add new action `switchArchiveLeague`
* add 'archived' status to existing action `editLeague` to ensure redux store stays in sync with Mongoose

In `client/src/components/dashboard/leagueTabs/leagueTabData.js`
* add data for a new 'sub-tab' in the 'settings' tab

Write new file `client/src/components/dashboard/settings/forms/LeagueArchiveForm.jsx` to provide UI in new 'sub-tab

In `client/src/components/dashboard/settings/forms/editLeageNameForm.jsx`
* add PropType validation to deal with linting errors (no change to functional code)

In `client/src/components/dashboard/settings/routes.jsx`and `client/src/components/routes.js`
* add new routes

In `client/src/components/nav/Menu.jsx` and `client/src/components/nav/MenuLeagueItem.jsx`
* refactor code for presenting leagues (which is now used twice) into separate component
* additional code to render the two lists (normal and 'archived') as appropriate
* additional code to style icons

 In `client/src/components/styles/cssDashboard.js` and `client/src/components/styles/cssMenu.js`
* additional styling rules

In `server/models/league.js`
* update schema/model to include 'archived' key

In `server/api/auth.js`
* update query method to include 'archived' value in return from Mongoose/MongoDB

In `server/api/league.js`
* update server methods to include 'archived' value
