### PR TITLE
faster webpack build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,8 +2,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
 
 
-module.exports = {
-	devtool: 'source-map',
+module.exports = env =>({
+	mode: env.mode,
+	devtool: env.mode === 'development' ? 'cheap-module-eval-source-map' : 'source-map',
 	entry: './client/index.js',
 	output: {
 		path: '/',
@@ -40,4 +41,4 @@ module.exports = {
 			template: 'client/index.html'
 		})
 	]
-};
+});

--- a/webpack.dev.middleware.js
+++ b/webpack.dev.middleware.js
@@ -1,5 +1,5 @@
 const webpackMiddleware = require('webpack-dev-middleware');
 const webpack = require('webpack');
-const webpackConfig = require('./webpack.config.js');
+const webpackConfig = require('./webpack.config.js')({mode: 'development'});
 
 module.exports = webpackMiddleware(webpack(webpackConfig));


### PR DESCRIPTION
i modified the webpack config file so the default mode is development mode for faster build since webpack 4 fallback to production mode if there is no mode provided which takes longer time to build

also i injected the mode into the webpack config in a way that allows us to add more configurations dynamically to the webpack

also i changed the devtool to cheap-module-eval-source-map cause it gives a faster rebuild and build