### PR TITLE
Fix for broken link to contributor's guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,1 +1,1 @@
-All Open Source for Good projects follow Free Code Camp's [contributor's guide](https://github.com/FreeCodeCamp/FreeCodeCamp/blob/staging/CONTRIBUTING.md).
+All Open Source for Good projects follow Free Code Camp's [contributor's guide](https://github.com/freeCodeCamp/freeCodeCamp/blob/master/CONTRIBUTING.md).


### PR DESCRIPTION
Maybe even add a link to Free Code Camp's new to open source guide? 

Example:
For a list of resources for people who are new to contributing to open source, check out [how to contribute to open source](https://github.com/freeCodeCamp/how-to-contribute-to-open-source).