### PR TITLE
fix/passport-google-oauth20@2

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "nodemailer": "^4.6.4",
     "nodemon": "^1.17.3",
     "passport": "^0.4.0",
-    "passport-google-oauth20": "^1.0.0",
+    "passport-google-oauth20": "^2.0.0",
     "prop-types": "^15.6.1",
     "react": "^16.3.2",
     "react-dom": "^16.3.2",


### PR DESCRIPTION
Adding the new passport-google-oauth as [advised](https://medium.com/passportjs/google-api-shutdown-330c3b47e3df) to account for Google+ API susetting.

This is for issue #124.