### PR TITLE
Fixing Active Team Filter

### DIFF
--- a/client/src/components/dashboard/teams/team_list/teamList.jsx
+++ b/client/src/components/dashboard/teams/team_list/teamList.jsx
@@ -35,9 +35,9 @@ class TeamTable extends Component {
 			if (filterValue === 'all') {
 				filterFlag = true;
 			} else if (filterValue === 'active') {
-				filterFlag = team.currentlyActive;
-			} else {
 				filterFlag = !team.currentlyActive;
+			} else {
+				filterFlag = team.currentlyActive;
 			}
 
 			return filterFlag;


### PR DESCRIPTION
The filter was backwards for filtering Active vs. Non-Active Teams.

`filterFlag` should be `false` if we don't want to filter that team.

Should resolve issue #99 